### PR TITLE
Update flash-loader.coffee

### DIFF
--- a/lib/flash-loader.coffee
+++ b/lib/flash-loader.coffee
@@ -40,7 +40,8 @@ validatePath = (path) ->
   p = path
   try
     fs.accessSync p
-    if not p.endsWith FILENAME
+    stats = fs.statSync p
+    if stats.isDirectory()
       p = join path, FILENAME
       fs.accessSync p
   catch


### PR DESCRIPTION
fixed the bug in validatePath function: when the FILENAME is as"pepflashplayer64_30_0_0_113.dll",it will not find it.